### PR TITLE
fix: introduces tx description states

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,7 @@ module.exports = {
     'object-curly-newline': 0,
     'operator-linebreak': 0,
     'no-bitwise': 0,
+    'no-mixed-operators': 0,
     'react/display-name': 2,
     'react/forbid-prop-types': 0,
     'react/jsx-closing-bracket-location': 0,

--- a/src/components/Tx/SendTx/TxDescription.jsx
+++ b/src/components/Tx/SendTx/TxDescription.jsx
@@ -6,6 +6,8 @@ import * as util from '../../../lib/util'
 
 import DeployContract from './TxDescription/DeployContract'
 import TokenTransfer from './TxDescription/TokenTransfer'
+import FunctionExecution from './TxDescription/FunctionExecution'
+import SendEther from './TxDescription/SendEther'
 
 // TODO
 const web3 = {}
@@ -89,42 +91,16 @@ export default class TxDescription extends Component {
     return 'etherTransfer'
   }
 
-  renderGenericFunctionDescription = () => {
-    return (
-      <div className="context-description__sentence">
-        Executing <span className="bold">Contract Function</span>
-      </div>
-    )
-  }
-
-  renderEtherTransferDescription() {
-    const { network } = this.props
-    let conversion
-    if (network === 'main') {
-      const value = this.calculateTransferValue()
-      if (value) {
-        conversion = <span>About {value} USD</span>
-      }
-    } else {
-      conversion = (
-        <span>
-          $0 (<span className="capitalize">{network}</span>)
-        </span>
-      )
-    }
-
-    return (
-      <div className="context-description__sentence">
-        <div>
-          Transfer <span className="bold">{this.formattedBalance()} ETHER</span>
-        </div>
-        <div className="context-description__subtext">{conversion}</div>
-      </div>
-    )
-  }
-
   renderDescription() {
-    const { data, params, token } = this.props
+    const {
+      etherPriceUSD,
+      executionFunction,
+      data,
+      params,
+      network,
+      token,
+      value
+    } = this.props
 
     const txType = this.determineTxType()
     switch (txType) {
@@ -133,11 +109,15 @@ export default class TxDescription extends Component {
       case 'tokenTransfer':
         return <TokenTransfer params={params} token={token} />
       case 'genericFunctionExecution':
-        return this.renderGenericFunctionDescription()
-      case 'etherTransfer':
-        return this.renderEtherTransferDescription()
+        return <FunctionExecution executionFunction={executionFunction} />
       default:
-        return this.renderEtherTransferDescription()
+        return (
+          <SendEther
+            network={network}
+            value={util.weiToEther(value)}
+            valueInUSD={util.toUsd(value, etherPriceUSD)}
+          />
+        )
     }
   }
 

--- a/src/components/Tx/SendTx/TxDescription.jsx
+++ b/src/components/Tx/SendTx/TxDescription.jsx
@@ -9,6 +9,8 @@ import TokenTransfer from './TxDescription/TokenTransfer'
 import FunctionExecution from './TxDescription/FunctionExecution'
 import SendEther from './TxDescription/SendEther'
 
+import { Button } from '../../..'
+
 // TODO
 const web3 = {}
 
@@ -16,12 +18,6 @@ export default class TxDescription extends Component {
   static displayName = 'TxDescription'
 
   static propTypes = {
-    // txType: PropTypes.oneOf([
-    // 'sendEth',
-    // 'transferTokens',
-    // 'deployContract',
-    // 'executeFunction'
-    // ]),
     network: PropTypes.oneOf(['main']),
     /** some ether value FIXME underspecified */
     value: PropTypes.string,
@@ -35,12 +31,13 @@ export default class TxDescription extends Component {
     params: PropTypes.object,
     data: PropTypes.object,
     adjustWindowHeight: PropTypes.func,
-    showDetails: PropTypes.bool,
     gasPrice: PropTypes.string,
     estimatedGas: PropTypes.string
   }
 
-  static defaultProps = {
+  static defaultProps = {}
+
+  state = {
     showDetails: false
   }
 
@@ -72,7 +69,7 @@ export default class TxDescription extends Component {
 
   handleDetailsClick = () => {
     const { adjustWindowHeight } = this.props
-    const { showDetails } = this.props
+    const { showDetails } = this.state
     this.setState({ showDetails: !showDetails }, adjustWindowHeight)
   }
 
@@ -155,11 +152,13 @@ export default class TxDescription extends Component {
 
     if (!showDetails) {
       return (
-        <div
+        <Button
+          flat
+          secondary
           className="execution-context__details-link"
           onClick={this.handleDetailsClick}>
           {i18n.t('mist.sendTx.showDetails')}
-        </div>
+        </Button>
       )
     }
 
@@ -261,11 +260,13 @@ export default class TxDescription extends Component {
           </div>
         )}
 
-        <div
+        <Button
+          flat
+          secondary
           className="execution-context__details-link"
           onClick={this.handleDetailsClick}>
           {i18n.t('mist.sendTx.hideDetails')}
-        </div>
+        </Button>
       </div>
     )
   }

--- a/src/components/Tx/SendTx/TxDescription.jsx
+++ b/src/components/Tx/SendTx/TxDescription.jsx
@@ -4,6 +4,9 @@ import i18n from '../../../i18n'
 import { Identicon } from '../..'
 import * as util from '../../../lib/util'
 
+import DeployContract from './TxDescription/DeployContract'
+import TokenTransfer from './TxDescription/TokenTransfer'
+
 // TODO
 const web3 = {}
 
@@ -11,6 +14,12 @@ export default class TxDescription extends Component {
   static displayName = 'TxDescription'
 
   static propTypes = {
+    // txType: PropTypes.oneOf([
+    // 'sendEth',
+    // 'transferTokens',
+    // 'deployContract',
+    // 'executeFunction'
+    // ]),
     network: PropTypes.oneOf(['main']),
     /** some ether value FIXME underspecified */
     value: PropTypes.string,
@@ -67,6 +76,7 @@ export default class TxDescription extends Component {
 
   determineTxType = () => {
     const { isNewContract, toIsContract, executionFunction } = this.props
+
     if (isNewContract) return 'newContract'
     if (toIsContract) {
       if (executionFunction === 'transfer(address,uint256)') {
@@ -77,40 +87,6 @@ export default class TxDescription extends Component {
     }
 
     return 'etherTransfer'
-  }
-
-  renderNewContractDescription = () => {
-    const { data } = this.props
-    const bytesCount = encodeURI(data).split(/%..|./).length - 1
-
-    return (
-      <div className="context-description__sentence">
-        <div>
-          Upload <span className="bold">New Contract</span>
-        </div>
-        <div className="context-description__subtext">
-          About {bytesCount} bytes
-        </div>
-      </div>
-    )
-  }
-
-  renderTokenTransferDescription = () => {
-    const { params, token } = this.props
-    if (params.length === 0) return <div />
-
-    const tokenCount = params[1].value.slice(0, -Math.abs(token.decimals))
-
-    const tokenSymbol = token.symbol || i18n.t('mist.sendTx.tokens')
-
-    return (
-      <div className="context-description__sentence">
-        {i18n.t('mist.sendTx.transfer')}{' '}
-        <span className="bold">
-          {tokenCount} {tokenSymbol}
-        </span>
-      </div>
-    )
   }
 
   renderGenericFunctionDescription = () => {
@@ -148,12 +124,14 @@ export default class TxDescription extends Component {
   }
 
   renderDescription() {
+    const { data, params, token } = this.props
+
     const txType = this.determineTxType()
     switch (txType) {
       case 'newContract':
-        return this.renderNewContractDescription()
+        return <DeployContract data={data} />
       case 'tokenTransfer':
-        return this.renderTokenTransferDescription()
+        return <TokenTransfer params={params} token={token} />
       case 'genericFunctionExecution':
         return this.renderGenericFunctionDescription()
       case 'etherTransfer':
@@ -314,6 +292,7 @@ export default class TxDescription extends Component {
 
   render() {
     const { gasError } = this.props
+
     return (
       <div className="execution-context">
         <div className="context-description">

--- a/src/components/Tx/SendTx/TxDescription/DeployContract.jsx
+++ b/src/components/Tx/SendTx/TxDescription/DeployContract.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
 export default class DeployContract extends Component {
+  static displayName = 'DeployContract'
+
   static propTypes = {
     data: PropTypes.string
   }
@@ -15,7 +17,7 @@ export default class DeployContract extends Component {
     return (
       <StyledWrapper>
         <div>
-          Upload <Bold>New Contract</Bold>
+          <Bold>Upload</Bold> New Contract
         </div>
         <StyledSubtext className="context-description__subtext">
           About {bytesCount} bytes

--- a/src/components/Tx/SendTx/TxDescription/DeployContract.jsx
+++ b/src/components/Tx/SendTx/TxDescription/DeployContract.jsx
@@ -1,0 +1,41 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+
+export default class DeployContract extends Component {
+  static propTypes = {
+    data: PropTypes.string
+  }
+
+  render() {
+    const { data } = this.props
+
+    const bytesCount = encodeURI(data).split(/%..|./).length - 1
+
+    return (
+      <StyledWrapper>
+        <div>
+          Upload <Bold>New Contract</Bold>
+        </div>
+        <StyledSubtext className="context-description__subtext">
+          About {bytesCount} bytes
+        </StyledSubtext>
+      </StyledWrapper>
+    )
+  }
+}
+
+const StyledWrapper = styled.div`
+  margin: 18px 0 24px;
+  font-size: 36px;
+  text-align: left;
+`
+
+const StyledSubtext = styled.div`
+  font-size: 16px;
+  margin: 12px 0;
+`
+
+const Bold = styled.span`
+  font-weight: bold;
+`

--- a/src/components/Tx/SendTx/TxDescription/FunctionExecution.jsx
+++ b/src/components/Tx/SendTx/TxDescription/FunctionExecution.jsx
@@ -1,0 +1,45 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { formatFunctionName } from '../../../../util/formatters'
+
+export default class FunctionExecution extends Component {
+  static displayName = 'FunctionExecution'
+
+  static propTypes = {
+    executionFunction: PropTypes.string
+  }
+
+  static defaultProps = {
+    executionFunction: ''
+  }
+
+  render() {
+    const { executionFunction } = this.props
+
+    const executionFunctionClean = formatFunctionName(executionFunction)
+
+    return (
+      <StyledWrapper>
+        <Bold>Execute </Bold>
+        {executionFunctionClean ? (
+          <React.Fragment>
+            &#8220;{executionFunctionClean}&#8221; function
+          </React.Fragment>
+        ) : (
+          <React.Fragment>contract function</React.Fragment>
+        )}
+      </StyledWrapper>
+    )
+  }
+}
+
+const StyledWrapper = styled.div`
+  margin: 18px 0 24px;
+  font-size: 36px;
+  text-align: left;
+`
+
+const Bold = styled.span`
+  font-weight: bold;
+`

--- a/src/components/Tx/SendTx/TxDescription/SendEther.jsx
+++ b/src/components/Tx/SendTx/TxDescription/SendEther.jsx
@@ -1,0 +1,57 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+
+export default class SendEther extends Component {
+  static displayName = 'SendEther'
+
+  static propTypes = {
+    network: PropTypes.string,
+    valueInUSD: PropTypes.string,
+    value: PropTypes.string
+  }
+
+  static defaultProps = {}
+
+  render() {
+    const { valueInUSD, network, value } = this.props
+
+    let conversion = <span>About ${valueInUSD} USD</span>
+
+    if (network !== 'main') {
+      conversion = (
+        <span>
+          $0 (<Capitalize>{network}</Capitalize>)
+        </span>
+      )
+    }
+
+    return (
+      <StyledWrapper>
+        <div>
+          <Bold>Transfer</Bold> {value} ETHER
+        </div>
+        <StyledSubtext>{conversion}</StyledSubtext>
+      </StyledWrapper>
+    )
+  }
+}
+
+const StyledWrapper = styled.div`
+  margin: 18px 0 24px;
+  font-size: 36px;
+  text-align: left;
+`
+
+const StyledSubtext = styled.div`
+  font-size: 16px;
+  margin: 12px 0;
+`
+
+const Bold = styled.span`
+  font-weight: bold;
+`
+
+const Capitalize = styled.span`
+  text-transform: capitalize;
+`

--- a/src/components/Tx/SendTx/TxDescription/SendEther.jsx
+++ b/src/components/Tx/SendTx/TxDescription/SendEther.jsx
@@ -7,14 +7,15 @@ export default class SendEther extends Component {
 
   static propTypes = {
     network: PropTypes.string,
-    valueInUSD: PropTypes.string,
-    value: PropTypes.string
+    value: PropTypes.string,
+    valueInUSD: PropTypes.string
   }
 
   static defaultProps = {}
 
   render() {
-    const { valueInUSD, network, value } = this.props
+    console.log('∆∆∆ this.props', this.props)
+    const { network, value, valueInUSD } = this.props
 
     let conversion = <span>About ${valueInUSD} USD</span>
 
@@ -29,7 +30,7 @@ export default class SendEther extends Component {
     return (
       <StyledWrapper>
         <div>
-          <Bold>Transfer</Bold> {value} ETHER
+          <Bold>Transfer</Bold> {value.toString} ETHER
         </div>
         <StyledSubtext>{conversion}</StyledSubtext>
       </StyledWrapper>

--- a/src/components/Tx/SendTx/TxDescription/TokenTransfer.jsx
+++ b/src/components/Tx/SendTx/TxDescription/TokenTransfer.jsx
@@ -1,0 +1,43 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import i18n from '../../../../i18n'
+import { formatTokenCount } from '../../../../util/formatters'
+
+export default class TokenTransfer extends Component {
+  static propTypes = {
+    params: PropTypes.array,
+    token: PropTypes.object
+  }
+
+  static defaultProps = {
+    token: { decimals: 18 }
+  }
+
+  render() {
+    const { params, token } = this.props
+
+    if (params.length === 0) return null
+
+    const tokenCount = formatTokenCount(params[1].value, token.decimals)
+
+    const tokenSymbol = token.symbol || i18n.t('mist.sendTx.tokens')
+
+    return (
+      <StyledWrapper>
+        <Bold>{i18n.t('mist.sendTx.transfer')} </Bold>
+        {tokenCount} {tokenSymbol}
+      </StyledWrapper>
+    )
+  }
+}
+
+const StyledWrapper = styled.div`
+  margin: 18px 0 24px;
+  font-size: 36px;
+  text-align: left;
+`
+
+const Bold = styled.span`
+  font-weight: bold;
+`

--- a/src/components/Tx/SendTx/TxDescription/TokenTransfer.jsx
+++ b/src/components/Tx/SendTx/TxDescription/TokenTransfer.jsx
@@ -5,6 +5,8 @@ import i18n from '../../../../i18n'
 import { formatTokenCount } from '../../../../util/formatters'
 
 export default class TokenTransfer extends Component {
+  static displayName = 'TokenTransfer'
+
   static propTypes = {
     params: PropTypes.array,
     token: PropTypes.object

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import ethUtils from 'ethereumjs-util'
 
 const BigNumber = ethUtils.BN
@@ -7,7 +6,7 @@ const isHex = str => typeof str === 'string' && str.startsWith('0x')
 export const toBN = str => new BigNumber(str)
 export const hexToNumberString = str => toBN(str).toString(10)
 
-export const toBigNumber = (str) => {
+export const toBigNumber = str => {
   /**
    web3.utils.isHex(estimatedGas)
       ? new BigNumber(web3.utils.hexToNumberString(estimatedGas))
@@ -16,26 +15,24 @@ export const toBigNumber = (str) => {
   return isHex(str) ? new BigNumber(hexToNumberString(str)) : new BigNumber(str)
 }
 
-export const weiToEther = (valWei) => {
+export const weiToEther = valWei => {
   return toBigNumber(valWei).div(new BigNumber('1000000000000000000'))
 }
 
-export const etherToGwei = (valEther) => {
+export const etherToGwei = valEther => {
   return new BigNumber(valEther).mul(new BigNumber('1000000000'))
 }
 
 export const toUsd = (etherAmount, format, etherPriceUSD) => {
   return toBigNumber(etherAmount)
-        .mul(new BigNumber(etherPriceUSD))
-        .toString()
-        .toFixed(2);
+    .mul(new BigNumber(etherPriceUSD))
+    .toString()
+    .toFixed(2)
 }
 
-export const networkIdToName = (str) => {
+export const networkIdToName = str => {
   return str
 }
 
 // FIXME wrapper for EthTools.formatBalance
-export const formatBalance = () => {
-
-}
+export const formatBalance = () => {}

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -23,11 +23,10 @@ export const etherToGwei = valEther => {
   return new BigNumber(valEther).mul(new BigNumber('1000000000'))
 }
 
-export const toUsd = (etherAmount, format, etherPriceUSD) => {
-  return toBigNumber(etherAmount)
-    .mul(new BigNumber(etherPriceUSD))
-    .toString()
-    .toFixed(2)
+export const toUsd = (etherAmount = '0', etherPriceUSD) => {
+  return parseFloat(
+    toBigNumber(etherAmount).mul(toBigNumber(etherPriceUSD))
+  ).toFixed(2)
 }
 
 export const networkIdToName = str => {

--- a/src/stories/3.Tx.stories.jsx
+++ b/src/stories/3.Tx.stories.jsx
@@ -4,6 +4,8 @@ import FeeSelector from '../components/Tx/SendTx/FeeSelector'
 import TxHistory from '../components/Tx/History'
 import FormSubmitTx from '../components/Tx/SendTx/FormSubmitTx'
 import TxDescription from '../components/Tx/SendTx/TxDescription'
+import DeployContract from '../components/Tx/SendTx/TxDescription/DeployContract'
+import TokenTransfer from '../components/Tx/SendTx/TxDescription/TokenTransfer'
 import GasNotification from '../components/Tx/SendTx/GasNotification'
 import TxParties from '../components/Tx/SendTx/TxParties'
 import TxParty from '../components/Tx/SendTx/TxParty'
@@ -27,9 +29,38 @@ storiesOf('Tx/Submit Form', module)
   .add('confirming', () => <FormSubmitTx unlocking />)
   .add('error', () => <FormSubmitTx error />)
 
-storiesOf('Tx/Description', module).add('default', () => {
-  return <TxDescription />
+storiesOf('Tx/Description/DeployContract', module).add('with data', () => {
+  return <DeployContract data={'a'.repeat(500)} />
 })
+
+storiesOf('Tx/Description/TokenTransfer', module)
+  .add('with token data', () => {
+    return (
+      <TokenTransfer
+        params={[{ value: '?' }, { value: '800000000000000' }]}
+        token={{ symbol: 'LOL', decimals: 18 }}
+      />
+    )
+  })
+  .add('without token data', () => {
+    return (
+      <TokenTransfer params={[{ value: '?' }, { value: '800000000000000' }]} />
+    )
+  })
+
+storiesOf('Tx/Description', module)
+  .add('send ETH', () => {
+    return <TxDescription txType="sendEth" />
+  })
+  .add('send tokens', () => {
+    return <TxDescription txType="transferTokens" />
+  })
+  .add('deploy contract', () => {
+    return <TxDescription txType="deployContract" />
+  })
+  .add('execute function', () => {
+    return <TxDescription txType="executeFunction" />
+  })
 
 storiesOf('Tx/TxParty', module)
   .add('origin', () => {

--- a/src/stories/3.Tx.stories.jsx
+++ b/src/stories/3.Tx.stories.jsx
@@ -3,9 +3,11 @@ import { storiesOf } from '@storybook/react'
 import FeeSelector from '../components/Tx/SendTx/FeeSelector'
 import TxHistory from '../components/Tx/History'
 import FormSubmitTx from '../components/Tx/SendTx/FormSubmitTx'
-import TxDescription from '../components/Tx/SendTx/TxDescription'
+// import TxDescription from '../components/Tx/SendTx/TxDescription'
 import DeployContract from '../components/Tx/SendTx/TxDescription/DeployContract'
 import TokenTransfer from '../components/Tx/SendTx/TxDescription/TokenTransfer'
+import FunctionExecution from '../components/Tx/SendTx/TxDescription/FunctionExecution'
+import SendEther from '../components/Tx/SendTx/TxDescription/SendEther'
 import GasNotification from '../components/Tx/SendTx/GasNotification'
 import TxParties from '../components/Tx/SendTx/TxParties'
 import TxParty from '../components/Tx/SendTx/TxParty'
@@ -48,18 +50,20 @@ storiesOf('Tx/Description/TokenTransfer', module)
     )
   })
 
-storiesOf('Tx/Description', module)
-  .add('send ETH', () => {
-    return <TxDescription txType="sendEth" />
+storiesOf('Tx/Description/SendEther', module)
+  .add('default', () => {
+    return <SendEther value="0.03" valueInUSD="3" network="main" />
   })
-  .add('send tokens', () => {
-    return <TxDescription txType="transferTokens" />
+  .add('transfer', () => {
+    return <SendEther value="0.03" valueInUSD="3" network="rinkeby" />
   })
-  .add('deploy contract', () => {
-    return <TxDescription txType="deployContract" />
+
+storiesOf('Tx/Description/FunctionExecution', module)
+  .add('default', () => {
+    return <FunctionExecution />
   })
-  .add('execute function', () => {
-    return <TxDescription txType="executeFunction" />
+  .add('transfer', () => {
+    return <FunctionExecution executionFunction="transfer(uint256,address)" />
   })
 
 storiesOf('Tx/TxParty', module)

--- a/src/stories/3.Tx.stories.jsx
+++ b/src/stories/3.Tx.stories.jsx
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react'
 import FeeSelector from '../components/Tx/SendTx/FeeSelector'
 import TxHistory from '../components/Tx/History'
 import FormSubmitTx from '../components/Tx/SendTx/FormSubmitTx'
-// import TxDescription from '../components/Tx/SendTx/TxDescription'
+import TxDescription from '../components/Tx/SendTx/TxDescription'
 import DeployContract from '../components/Tx/SendTx/TxDescription/DeployContract'
 import TokenTransfer from '../components/Tx/SendTx/TxDescription/TokenTransfer'
 import FunctionExecution from '../components/Tx/SendTx/TxDescription/FunctionExecution'
@@ -21,7 +21,11 @@ const dummyTx = {
   data: '',
   gasPrice: '0x9184e72a000', // 10000000000000
   value: '1000000000000000000',
-  params: [{ value: '0x4444444444444444444444444444444444444444' }]
+  params: [
+    { value: '0x4444444444444444444444444444444444444444' },
+    { value: '20000000000000000' }
+  ],
+  network: 'main'
 }
 
 storiesOf('Tx/Fee Selector', module).add('default ', () => <FeeSelector />)
@@ -30,6 +34,33 @@ storiesOf('Tx/Submit Form', module)
   .add('default', () => <FormSubmitTx />)
   .add('confirming', () => <FormSubmitTx unlocking />)
   .add('error', () => <FormSubmitTx error />)
+
+storiesOf('Tx/Description', module)
+  .add('default', () => {
+    return <TxDescription {...dummyTx} />
+  })
+  .add('deploy contract', () => {
+    return <TxDescription {...dummyTx} isNewContract={true} />
+  })
+  .add('transfer tokens', () => {
+    return (
+      <TxDescription
+        {...dummyTx}
+        executionFunction="transfer(address,uint256)"
+        token={{ symbol: 'LOL', decimals: 18 }}
+        toIsContract
+      />
+    )
+  })
+  .add('execute function', () => {
+    return (
+      <TxDescription
+        {...dummyTx}
+        executionFunction="approve(uint256)"
+        toIsContract
+      />
+    )
+  })
 
 storiesOf('Tx/Description/DeployContract', module).add('with data', () => {
   return <DeployContract data={'a'.repeat(500)} />

--- a/src/util/formatters.js
+++ b/src/util/formatters.js
@@ -1,0 +1,16 @@
+export function formatTokenCount(value, decimals) {
+  return Number(value / 10 ** decimals).toString()
+}
+
+export function formatFunctionName(functionName) {
+  if (functionName === undefined) {
+    throw new Error('formatFunctionName() expects a non-empty string')
+  }
+
+  return functionName
+    .slice(0, functionName.indexOf('('))
+    .replace(/_+/g, ' ')
+    .replace(/([A-Z]+|[0-9]+)/g, ' $1')
+    .toLowerCase()
+    .trim()
+}


### PR DESCRIPTION
#### What does it do?
- Introduces four tx description types: send eth, send tokens, execute function, deploy contract.
#### Any helpful background information?
Getting this out the door to turn attention to the wallet. TxDescription still needs more love before its said and done. The "show details" section remains, and the component API is still up for debate (e.g. should TxDescription accept a prop of `txType` which is one of 'sendEth', 'deployContract', etc. instead of reaching that conclusion internally based on props)
#### New dependencies? What are they used for?
n/a
#### Relevant screenshots?
![screen shot 2018-12-17 at 12 38 45 pm](https://user-images.githubusercontent.com/3621728/50113848-591f7480-0200-11e9-9d01-86c2b19a6e0a.png)
