### PR TITLE
fix: adds loading state to Button

### DIFF
--- a/src/components/Tx/SendTx/FeeSelector.jsx
+++ b/src/components/Tx/SendTx/FeeSelector.jsx
@@ -90,9 +90,7 @@ export default class FeeSelector extends Component {
 
     return (
       <React.Fragment>
-        {gasLoading && (
-          <Spinner singleColor="#00aafa" size={16} className="react-spinner" />
-        )}
+        {gasLoading && <Spinner color="#00aafa" scale="0.5" />}
         {error}
       </React.Fragment>
     )

--- a/src/components/Widgets/AnimatedIcons/Spinner.jsx
+++ b/src/components/Widgets/AnimatedIcons/Spinner.jsx
@@ -9,23 +9,25 @@ export default class Spinner extends Component {
   static displayName = 'Spinner'
 
   static propTypes = {
-    pstyle: PropTypes.any
+    scale: PropTypes.string,
+    color: PropTypes.string
+  }
+
+  static defaultProps = {
+    scale: '1',
+    color: '#AAA'
   }
 
   render() {
-    const { pstyle } = this.props
+    const { color, scale } = this.props
 
     const divCount = 8
-    const style = { backgroundColor: '#AAA' }
+    const style = { backgroundColor: color }
 
     return (
       <div
         className="loader"
-        style={{
-          ...pstyle,
-          width: '65px',
-          height: '65px'
-        }}>
+        style={{ transform: `scale(${scale}, ${scale})` }}>
         <div className="ball-spin-fade-loader">
           {[...Array(divCount)].map((_, idx) => (
             <div key={idx} style={style} />

--- a/src/components/Widgets/Button.jsx
+++ b/src/components/Widgets/Button.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
+import { Spinner } from '../..'
 
 export default class Button extends Component {
   static displayName = 'Button'
@@ -14,6 +15,7 @@ export default class Button extends Component {
     onClick: PropTypes.func,
     secondary: PropTypes.bool,
     type: PropTypes.oneOf(['button', 'reset', 'submit']),
+    /** If `true`, extra margin is added. See `SubmitFormTx` component for example usage. */
     withinInput: PropTypes.bool
   }
 
@@ -28,25 +30,38 @@ export default class Button extends Component {
   }
 
   render() {
-    const { children } = this.props
+    const { children, flat, loading, secondary } = this.props
+
+    const spinner = (
+      <Spinner color={!secondary && !flat ? 'white' : '#00aafa'} scale="0.5" />
+    )
 
     return (
       <StyledButton {...this.props} className="Button">
-        {children}
+        {loading ? spinner : children}
       </StyledButton>
     )
   }
 }
 
 const StyledButton = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
   background-color: #00aafa;
-  border: 1px solid #00aafa;
   border-radius: 4px;
+  border: 1px solid #00aafa;
   color: white;
-  padding: 12px 24px;
-  font-size: 14px;
-  text-transform: uppercase;
   cursor: pointer;
+  font-size: 14px;
+  height: 46px;
+  line-height: 1;
+  min-width: 120px;
+  overflow: hidden;
+  padding: 12px 24px;
+  text-decoration: none;
+  text-transform: uppercase;
+  white-space: nowrap;
 
   ${props =>
     props.secondary &&
@@ -65,7 +80,7 @@ const StyledButton = styled.button`
     `};
 
   ${props =>
-    props.disabled &&
+    (props.disabled || props.loading) &&
     css`
       cursor: not-allowed;
       opacity: 0.6;

--- a/src/stories/1.index.stories.jsx
+++ b/src/stories/1.index.stories.jsx
@@ -75,16 +75,42 @@ storiesOf('Widgets/Animations/Icons', module)
 
 storiesOf('Widgets/Button', module)
   .add('default', () => <Button>click me</Button>)
+  .add('loading', () => <Button loading>click me</Button>)
   .add('disabled', () => <Button disabled>click me</Button>)
   .add('secondary', () => <Button secondary>click me</Button>)
+  .add('secondary loading', () => (
+    <Button secondary loading>
+      click me
+    </Button>
+  ))
   .add('secondary disabled', () => (
     <Button secondary disabled>
       click me
     </Button>
   ))
   .add('flat', () => <Button flat>click me</Button>)
+  .add('flat loading', () => (
+    <Button flat loading>
+      click me
+    </Button>
+  ))
+  .add('flat disabled', () => (
+    <Button flat disabled>
+      click me
+    </Button>
+  ))
   .add('flat secondary', () => (
     <Button flat secondary>
+      click me
+    </Button>
+  ))
+  .add('flat secondary loading', () => (
+    <Button flat secondary loading>
+      click me
+    </Button>
+  ))
+  .add('flat secondary disabled', () => (
+    <Button flat secondary disabled>
       click me
     </Button>
   ))


### PR DESCRIPTION
#### What does it do?
Adds loading state to `Button`; this replaces the content of the button with a `Spinner` component and applies `disabled` styling. Closes #60.
#### Any helpful background information?
- This doesn't address Philipp's other Button styling critiques about resizing and active states. That'll be a follow-on PR after playing with some styling options.
- I used a min-width to prevent the button from shrinking too small after it changes to a loading state. Open to feedback on that UX.
#### New dependencies? What are they used for?
n/a
#### Relevant screenshots?
![screen shot 2018-12-20 at 4 09 28 pm](https://user-images.githubusercontent.com/3621728/50315917-cb4ac000-0471-11e9-8373-73b3b0232c6f.png)
