### PR TITLE
fix: cleanup for wallet components

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,6 @@
+<link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700" rel="stylesheet" />
+<style>
+* {
+  font-family: 'Source Sans Open', sans-serif;
+}
+</style>

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ import { Identicon } from 'ethereum-react-components';
 
 For a detailed documentation check out e.g. the [Identicon story](https://ethereum.github.io/ethereum-react-components?selectedKind=Widgets%2FIdenticon)
 
+Note that this storybook uses the [Source Sans Pro](https://fonts.google.com/specimen/Source+Sans+Pro?selection.family=Source+Sans+Pro:300,400,600,700) font.
+You'll need to import and apply this font (or another font of your choosing) in your own project.
+
 # Development
 
 ## Clone & Storybook

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.6.0",
     "@fortawesome/react-fontawesome": "^0.1.3",
     "axios": "^0.18.0",
+    "bignumber.js": "^8.0.1",
     "classnames": "^2.2.6",
     "cross-env": "^5.2.0",
     "ethereum-blockies": "git+https://github.com/ethereum/blockies.git",

--- a/src/components/Network/NodeInfo/NodeInfoBox.jsx
+++ b/src/components/Network/NodeInfo/NodeInfoBox.jsx
@@ -2,7 +2,6 @@ import React, { Component } from 'react'
 import moment from 'moment'
 import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
-import { library } from '@fortawesome/fontawesome-svg-core'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
   faShareAlt,
@@ -13,15 +12,6 @@ import {
   faClock
 } from '@fortawesome/free-solid-svg-icons'
 import i18n from '../../../i18n'
-
-library.add(
-  faShareAlt,
-  faUsers,
-  faBolt,
-  faLayerGroup,
-  faCloudDownloadAlt,
-  faClock
-)
 
 const numberWithCommas = val => {
   return val.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
@@ -73,7 +63,7 @@ export default class NodeInfoBox extends Component {
     return (
       <div>
         <div className="looking-for-peers row-icon">
-          <FontAwesomeIcon icon="share-alt" />
+          <FontAwesomeIcon icon={faShareAlt} />
           {i18n.t('mist.nodeInfo.lookingForPeers')}
         </div>
       </div>
@@ -87,11 +77,11 @@ export default class NodeInfoBox extends Component {
     return (
       <div>
         <div className="peer-count row-icon">
-          <FontAwesomeIcon icon="users" />
+          <FontAwesomeIcon icon={faUsers} />
           {` ${connectedPeers} ${i18n.t('mist.nodeInfo.peers')}`}
         </div>
         <div className="sync-starting row-icon">
-          <FontAwesomeIcon icon="bolt" />
+          <FontAwesomeIcon icon={faBolt} />
           {i18n.t('mist.nodeInfo.syncStarting')}
         </div>
       </div>
@@ -111,15 +101,15 @@ export default class NodeInfoBox extends Component {
     return (
       <div>
         <div className="block-number row-icon">
-          <FontAwesomeIcon icon="layer-group" />
+          <FontAwesomeIcon icon={faLayerGroup} />
           {formattedCurrentBlock}
         </div>
         <div className="peer-count row-icon">
-          <FontAwesomeIcon icon="users" />
+          <FontAwesomeIcon icon={faUsers} />
           {` ${connectedPeers} ${i18n.t('mist.nodeInfo.peers')}`}
         </div>
         <div className="sync-progress row-icon">
-          <FontAwesomeIcon icon="cloud-download-alt" />
+          <FontAwesomeIcon icon={faCloudDownloadAlt} />
           <progress max="100" value={progress || 0} />
         </div>
       </div>
@@ -141,26 +131,24 @@ export default class NodeInfoBox extends Component {
       <div>
         <div
           className="block-number row-icon"
-          title={i18n.t('mist.nodeInfo.blockNumber')}
-        >
-          <FontAwesomeIcon icon="layer-group" />
+          title={i18n.t('mist.nodeInfo.blockNumber')}>
+          <FontAwesomeIcon icon={faLayerGroup} />
           {formattedBlockNumber}
         </div>
         {network !== 'private' && (
           <div className="peer-count row-icon">
-            <FontAwesomeIcon icon="users" />
+            <FontAwesomeIcon icon={faUsers} />
             {` ${connectedPeers} ${i18n.t('mist.nodeInfo.peers')}`}
           </div>
         )}
         <div
           className={
             diff > 60 ? 'block-diff row-icon red' : 'block-diff row-icon'
-          }
-        >
+          }>
           {
             // TODO: make this i8n compatible
           }
-          <FontAwesomeIcon icon="clock" />
+          <FontAwesomeIcon icon={faClock} />
           {diff < 120 ? `${diff} seconds` : `${Math.floor(diff / 60)} minutes`}
         </div>{' '}
       </div>
@@ -190,7 +178,7 @@ export default class NodeInfoBox extends Component {
           </div>
           <div>
             <div className="remote-loading row-icon">
-              <FontAwesomeIcon icon="bolt" />
+              <FontAwesomeIcon icon={faBolt} />
               {i18n.t('mist.nodeInfo.connecting')}
             </div>
           </div>
@@ -206,18 +194,17 @@ export default class NodeInfoBox extends Component {
           </span>
         </div>
         <div className="block-number row-icon">
-          <FontAwesomeIcon icon="layer-group" />
+          <FontAwesomeIcon icon={faLayerGroup} />
           {formattedBlockNumber}
         </div>
         <div
           className={
             diff > 60 ? 'block-diff row-icon red' : 'block-diff row-icon'
-          }
-        >
+          }>
           {
             // TODO: make this i8n compatible
           }
-          <FontAwesomeIcon icon="clock" />
+          <FontAwesomeIcon icon={faClock} />
           {diff < 120 ? `${diff} seconds` : `${Math.floor(diff / 60)} minutes`}
         </div>
       </div>

--- a/src/components/Wallet/AccountItem.jsx
+++ b/src/components/Wallet/AccountItem.jsx
@@ -2,11 +2,8 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { library } from '@fortawesome/fontawesome-svg-core'
 import { faKey } from '@fortawesome/free-solid-svg-icons'
 import { Identicon, TokenListForItem, EthAddress } from '..'
-
-library.add(faKey)
 
 export default class AccountItem extends Component {
   static displayName = 'AccountItem'
@@ -36,7 +33,7 @@ export default class AccountItem extends Component {
 
         <FlexWrapper>
           <StyledName>
-            <FontAwesomeIcon icon="key" /> {name}
+            <StyledIcon icon={faKey} /> {name}
           </StyledName>
 
           <StyledBalance>
@@ -68,16 +65,20 @@ const StyledName = styled.div`
   color: #00aafa;
   text-transform: uppercase;
   font-style: italic;
-  font-weight: 500;
-  line-height: 20.5px;
+  font-weight: bold;
+  line-height: 20px;
   overflow: hidden;
   text-overflow: ellipsis;
+`
+
+const StyledIcon = styled(FontAwesomeIcon)`
+  width: 0.9em !important;
 `
 
 const StyledBalance = styled.div`
   color: #827a7a;
   font-size: 1.3em;
-  font-height: 1.35em;
+  line-height: 22px;
   text-overflow: ellipsis;
 `
 

--- a/src/components/Wallet/AccountItem.jsx
+++ b/src/components/Wallet/AccountItem.jsx
@@ -33,7 +33,7 @@ export default class AccountItem extends Component {
 
         <FlexWrapper>
           <StyledName>
-            <StyledIcon icon={faKey} /> {name}
+            <FontAwesomeIcon icon={faKey} style={{ width: '0.8em' }} /> {name}
           </StyledName>
 
           <StyledBalance>
@@ -69,10 +69,6 @@ const StyledName = styled.div`
   line-height: 20px;
   overflow: hidden;
   text-overflow: ellipsis;
-`
-
-const StyledIcon = styled(FontAwesomeIcon)`
-  width: 0.9em !important;
 `
 
 const StyledBalance = styled.div`

--- a/src/components/Wallet/NavbarItem.jsx
+++ b/src/components/Wallet/NavbarItem.jsx
@@ -34,6 +34,7 @@ const StyledWrapper = styled.div`
   align-items: center;
   justify-content: center;
   color: #0285c0;
+  padding: 6px 32px;
 `
 
 const StyledIcon = styled.div`

--- a/src/components/Wallet/NetworkStatus.jsx
+++ b/src/components/Wallet/NetworkStatus.jsx
@@ -76,6 +76,7 @@ export default class NetworkStatus extends Component {
 const StyledWrapper = styled.div`
   display: flex;
   flex-direction: column;
+  justify-content: center;
   color: #766a6a;
 `
 

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -1,9 +1,10 @@
 import ethUtils from 'ethereumjs-util'
+import { BigNumber as BNJS } from 'bignumber.js'
 
 const BigNumber = ethUtils.BN
 
 const isHex = str => typeof str === 'string' && str.startsWith('0x')
-export const toBN = str => new BigNumber(str)
+export const toBN = str => new BNJS(str)
 export const hexToNumberString = str => toBN(str).toString(10)
 
 export const toBigNumber = str => {
@@ -12,20 +13,20 @@ export const toBigNumber = str => {
       ? new BigNumber(web3.utils.hexToNumberString(estimatedGas))
       : new BigNumber(estimatedGas) 
    */
-  return isHex(str) ? new BigNumber(hexToNumberString(str)) : new BigNumber(str)
+  return isHex(str) ? new BNJS(hexToNumberString(str)) : new BNJS(str)
 }
 
 export const weiToEther = valWei => {
-  return toBigNumber(valWei).div(new BigNumber('1000000000000000000'))
+  return toBigNumber(valWei).div(new BNJS('1000000000000000000'))
 }
 
 export const etherToGwei = valEther => {
-  return new BigNumber(valEther).mul(new BigNumber('1000000000'))
+  return new BNJS(valEther).times(new BNJS('1000000000'))
 }
 
 export const toUsd = (etherAmount = '0', etherPriceUSD) => {
   return parseFloat(
-    toBigNumber(etherAmount).mul(toBigNumber(etherPriceUSD))
+    toBigNumber(etherAmount).times(toBigNumber(etherPriceUSD))
   ).toFixed(2)
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1959,6 +1959,10 @@ big.js@^3.1.3:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
 
+bignumber.js@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-8.0.1.tgz#5d419191370fb558c64e3e5f70d68e5947138832"
+
 binary-extensions@^1.0.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.12.0.tgz#c2d780f53d45bba8317a8902d4ceeaf3a6385b14"


### PR DESCRIPTION
#### What does it do?
- introduces bignumber.js for proper decimal handling (Closes #75)
- standardizes fontawesome icon usage
- adds font to storybook (not the components themselves)
- style tweaks notices while working on the wallet
#### Any helpful background information?
- the bignumber lib can be swapped out if we decide to handle this differently in the future. I saw this as the quickest way forward.
- `preview-head.html` is a storybook-specific file/feature to introduce custom scripts to the storybook server.
- I believe the `library` function in fontawesome is best used when all icons are imported in some top-level component. Since we have a modular component lib, I think it makes sense to skip this convenience function.
#### New dependencies? What are they used for?
[bignumber.js](http://mikemcl.github.io/bignumber.js/) -- handling decimal arithmetic 
#### Relevant screenshots?
lacking decimal logic before:
<img width="673" alt="screen shot 2019-01-03 at 10 58 12 am" src="https://user-images.githubusercontent.com/3621728/50653715-b4af6900-0f47-11e9-874d-bd232bd3ee02.png">
after:
<img width="674" alt="screen shot 2019-01-03 at 10 57 56 am" src="https://user-images.githubusercontent.com/3621728/50653714-b4af6900-0f47-11e9-8444-ab44c75dd582.png">
