### PR TITLE
feat: introduces AddressInput

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ A library of frequently used Ethereum React components to display and handle add
 
 For a detailed documentation of all available components check out [the generated storybook](https://ethereum.github.io/ethereum-react-components)
 
-WARNING: this lib is not production ready
+WARNING: this lib is not production ready. All component APIs are in exploratory phases and strict semantic versioning is not yet enforced.
 
 # Examples
 
 Two projects using these components are
 
-- [Mist React](https://github.com/ethereum/mist-ui-react)
+- [Mist React](https://github.com/ethereum/mist-ui)
 - [Mist](https://github.com/ethereum/mist)
 
 # Installation

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
   },
   "peerDependencies": {
     "react": ">=16.6.3",
-    "react-dom": ">=16.6.3",
-    "styled-jsx": "^3.x"
+    "react-dom": ">=16.6.3"
   },
   "author": "",
   "license": "ISC",
@@ -58,7 +57,6 @@
     "sass-loader": "^7.1.0",
     "standard-version": "^4.4.0",
     "style-loader": "^0.23.1",
-    "styled-jsx": "^3.1.2",
     "webpack": "^4.26.0",
     "webpack-cli": "^3.1.2"
   },

--- a/src/components/Identicon.jsx
+++ b/src/components/Identicon.jsx
@@ -16,7 +16,6 @@ export default class Identicon extends Component {
   static propTypes = {
     address: PropTypes.string,
     anonymous: PropTypes.bool,
-    classes: PropTypes.string,
     size: PropTypes.oneOf(['nano', 'tiny', 'small', 'medium', 'large'])
   }
 
@@ -39,11 +38,12 @@ export default class Identicon extends Component {
   }
 
   render() {
-    const { address, anonymous, size, classes } = this.props
+    const { address, anonymous, size } = this.props
 
     if (anonymous) {
       return (
         <StyledSpanAnonymous
+          {...this.props}
           backgroundImage={`url('${anonymousIcon}')`}
           size={size}
         />
@@ -51,12 +51,12 @@ export default class Identicon extends Component {
     }
 
     if (!address) {
-      return <StyledSpanEmpty size={size} />
+      return <StyledSpanEmpty {...this.props} size={size} />
     }
 
     return (
       <StyledSpan
-        className={classes}
+        {...this.props}
         backgroundImage={`url('${this.identiconData(address.toLowerCase())}')`}
         size={size}
         title={i18n.t('elements.identiconHelper')}>

--- a/src/components/Wallet/AccountItem.jsx
+++ b/src/components/Wallet/AccountItem.jsx
@@ -52,6 +52,7 @@ export default class AccountItem extends Component {
 const StyledWrapper = styled.div`
   display: flex;
   width: 220px;
+  margin-bottom: 12px;
 `
 
 const FlexWrapper = styled.div`

--- a/src/components/Widgets/AnimatedIcons/AnimatedCross.jsx
+++ b/src/components/Widgets/AnimatedIcons/AnimatedCross.jsx
@@ -8,7 +8,8 @@ export default class Cross extends Component {
   static displayName = 'AnimatedCross'
 
   static propTypes = {
-    size: PropTypes.number
+    size: PropTypes.number,
+    style: PropTypes.object
   }
 
   static defaultProps = {
@@ -16,7 +17,7 @@ export default class Cross extends Component {
   }
 
   render() {
-    const { size } = this.props
+    const { size, style } = this.props
 
     return (
       <svg
@@ -24,6 +25,7 @@ export default class Cross extends Component {
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 52 52"
         style={{
+          ...style,
           width: size,
           height: size
         }}>

--- a/src/components/Widgets/Form/AddressInput.jsx
+++ b/src/components/Widgets/Form/AddressInput.jsx
@@ -1,0 +1,80 @@
+import React, { Component } from 'react'
+// import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { Input, Identicon, utils } from '../..'
+import Cross from '../AnimatedIcons/AnimatedCross'
+
+export default class AddressInput extends Component {
+  static displayName = 'AddressInput'
+
+  static propTypes = {}
+
+  static defaultProps = {}
+
+  constructor(props) {
+    super(props)
+
+    this.state = { icon: null }
+  }
+
+  componentDidMount() {
+    const { value } = this.props
+
+    this.updateIcon(value)
+  }
+
+  updateIcon = value => {
+    const { onChange } = this.props
+
+    let icon
+    if (utils.isAddress(value)) {
+      icon = (
+        <Identicon
+          address={value}
+          size="tiny"
+          style={{ zIndex: 2, position: 'absolute', top: '8px', left: '12px' }}
+        />
+      )
+    } else if (value) {
+      icon = (
+        <Cross
+          size={24}
+          style={{ zIndex: 2, position: 'absolute', top: '6px' }}
+        />
+      )
+    } else {
+      icon = null
+    }
+
+    this.setState({ icon }, () => {
+      if (onChange) {
+        onChange(value)
+      }
+    })
+  }
+
+  render() {
+    const { icon } = this.state
+
+    return (
+      <StyledWrapper>
+        {icon}
+        <StyledInput
+          {...this.props}
+          onChange={e => this.updateIcon(e.target.value)}
+          placeholder="0x000000..."
+          type="text"
+        />
+      </StyledWrapper>
+    )
+  }
+}
+
+const StyledWrapper = styled.div`
+  position: relative;
+  display: inline-block;
+`
+
+const StyledInput = styled(Input)`
+  padding-left: 42px;
+`

--- a/src/components/Widgets/Form/Input.jsx
+++ b/src/components/Widgets/Form/Input.jsx
@@ -1,9 +1,41 @@
-import React from 'react'
+import React, { Component } from 'react'
+// import PropTypes from 'prop-types'
+import styled from 'styled-components'
 
-const Input = props => (
-  <input {...props} type="text" className="input-field input-text" />
-)
+export default class Input extends Component {
+  static displayName = 'Input'
 
-Input.displayName = 'Input'
+  static propTypes = {}
 
-export default Input
+  static defaultProps = {}
+
+  render() {
+    return <StyledInput {...this.props} type="text" />
+  }
+}
+
+const StyledInput = styled.input`
+  display: inline-block;
+  background-color: #f5f4f2;
+  border: 0;
+  border-bottom: solid 2px #dddcdb;
+  box-sizing: border-box;
+  color: #4a90e2;
+  font-size: 1em;
+  font-weight: 300;
+  height: 36.8px;
+  max-width: 100%;
+  padding: 10px 16px 8px;
+  transition-delay: 0s;
+  transition: background-color ease-in-out 1s, color ease-in-out 1s;
+  width: 440px;
+  z-index: 1;
+
+  :focus {
+    border-color: #02a8f3;
+  }
+
+  ::placeholder {
+    color: #ccc6c6;
+  }
+`

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -10,6 +10,7 @@ import Button from './Widgets/Button'
 import Checkbox from './Widgets/Checkbox'
 import RadioButton from './Widgets/Form/RadioButton'
 import Input from './Widgets/Form/Input'
+import AddressInput from './Widgets/Form/AddressInput'
 import TextArea from './Widgets/Form/TextArea'
 import Select from './Widgets/Form/Select'
 import FileChooser from './Widgets/Form/FileChooser'
@@ -26,9 +27,12 @@ import TokenListForItem from './Wallet/TokenListForItem'
 import NavbarItem from './Wallet/NavbarItem'
 import NetworkStatus from './Wallet/NetworkStatus'
 
+import * as utils from '../lib/util'
+
 export {
   AccountList,
   AccountItem,
+  AddressInput,
   Button,
   Checkbox,
   RadioButton,
@@ -53,5 +57,6 @@ export {
   Spinner,
   TokenListForItem,
   TxHistory,
-  ValidatedField
+  ValidatedField,
+  utils
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,1 @@
-export * from './components/index.js';
+export * from './components'

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -7,6 +7,8 @@ const isHex = str => typeof str === 'string' && str.startsWith('0x')
 export const toBN = str => new BNJS(str)
 export const hexToNumberString = str => toBN(str).toString(10)
 
+export const isAddress = str => isHex(str) && str.length === 42
+
 export const toBigNumber = str => {
   /**
    web3.utils.isHex(estimatedGas)

--- a/src/stories/1.index.stories.jsx
+++ b/src/stories/1.index.stories.jsx
@@ -10,6 +10,7 @@ import {
   Pulse,
   Button,
   Checkbox,
+  AddressInput,
   Input,
   TextArea,
   Select,
@@ -115,7 +116,20 @@ storiesOf('Widgets/Button', module)
     </Button>
   ))
 
-storiesOf('Widgets/Form/Input', module).add('default', () => <Input />)
+storiesOf('Widgets/Form/Input', module).add('default', () => (
+  <Input placeholder="Sample input..." />
+))
+
+storiesOf('Widgets/Form/AddressInput', module)
+  .add('empty state', () => {
+    return <AddressInput />
+  })
+  .add('error state', () => {
+    return <AddressInput value="0x0123" />
+  })
+  .add('success state', () => {
+    return <AddressInput value="0xF5A5d5c30BfAC14bf207b6396861aA471F9A711D" />
+  })
 
 storiesOf('Widgets/Form/TextArea', module).add('default', () => <TextArea />)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1778,7 +1778,7 @@ babel-plugin-react-docgen@^2.0.0:
     "@babel/plugin-syntax-jsx" "^7.0.0"
     lodash "^4.17.10"
 
-babel-plugin-syntax-jsx@6.18.0, babel-plugin-syntax-jsx@^6.18.0:
+babel-plugin-syntax-jsx@^6.18.0:
   version "6.18.0"
   resolved "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
 
@@ -1916,7 +1916,7 @@ babel-traverse@^6.0.0, babel-traverse@^6.18.0, babel-traverse@^6.26.0:
     invariant "^2.2.2"
     lodash "^4.17.4"
 
-babel-types@6.26.0, babel-types@^6.0.0, babel-types@^6.18.0, babel-types@^6.26.0:
+babel-types@^6.0.0, babel-types@^6.18.0, babel-types@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   dependencies:
@@ -2669,10 +2669,6 @@ conventional-recommended-bump@^1.0.0:
     git-semver-tags "^1.3.0"
     meow "^3.3.0"
     object-assign "^4.0.1"
-
-convert-source-map@1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
 
 convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.5.0, convert-source-map@^1.5.1:
   version "1.6.0"
@@ -7956,10 +7952,6 @@ source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
 
-source-map@0.7.3, source-map@^0.7.2:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
-
 source-map@^0.4.2:
   version "0.4.4"
   resolved "http://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
@@ -7973,6 +7965,10 @@ source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7:
 source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+
+source-map@^0.7.2:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
 
 spdx-correct@^3.0.0:
   version "3.0.2"
@@ -8107,10 +8103,6 @@ stream-http@^2.7.2:
 stream-shift@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
-
-string-hash@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/string-hash/-/string-hash-1.1.3.tgz#e8aafc0ac1855b4666929ed7dd1275df5d6c811b"
 
 string-length@^2.0.0:
   version "2.0.0"
@@ -8248,26 +8240,9 @@ styled-components@^4.1.1:
     stylis-rule-sheet "^0.0.10"
     supports-color "^5.5.0"
 
-styled-jsx@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-3.1.2.tgz#d420add6f43d41aea942fb289db43a25afc3d898"
-  dependencies:
-    babel-plugin-syntax-jsx "6.18.0"
-    babel-types "6.26.0"
-    convert-source-map "1.5.1"
-    loader-utils "1.1.0"
-    source-map "0.7.3"
-    string-hash "1.1.3"
-    stylis "3.5.3"
-    stylis-rule-sheet "0.0.10"
-
-stylis-rule-sheet@0.0.10, stylis-rule-sheet@^0.0.10:
+stylis-rule-sheet@^0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
-
-stylis@3.5.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.3.tgz#99fdc46afba6af4deff570825994181a5e6ce546"
 
 stylis@^3.5.0:
   version "3.5.4"


### PR DESCRIPTION
#### What does it do?
- Introduces `AddressInput` wallet component; Closes #78 
- Makes component lib utils available for import: e.g. `import { AddressInput, utils } from 'ethereum-react-components'`
- Adds style extensibility to `Identicon` + `Cross` components for positioning within `AddressInput`
- Removes `styled-jsx` dep
#### Relevant screenshots?
<img width="461" alt="screen shot 2019-01-05 at 6 23 45 pm" src="https://user-images.githubusercontent.com/3621728/50730990-1540d080-1117-11e9-897d-aa57e568439f.png">
