### PR TITLE
feat: Notification

### DIFF
--- a/src/components/Wallet/NavbarItem.jsx
+++ b/src/components/Wallet/NavbarItem.jsx
@@ -18,7 +18,7 @@ export default class NavbarItem extends Component {
     const { icon, title } = this.props
 
     return (
-      <StyledWrapper>
+      <StyledWrapper {...this.props}>
         <StyledIcon>
           <FontAwesomeIcon icon={icons[icon]} />
         </StyledIcon>

--- a/src/components/Wallet/NetworkStatus.jsx
+++ b/src/components/Wallet/NetworkStatus.jsx
@@ -20,8 +20,7 @@ export default class NetworkStatus extends Component {
 
   static defaultProps = {
     peers: 0,
-    blockNumber: '0',
-    timestamp: moment().unix()
+    blockNumber: '-'
   }
 
   constructor(props) {
@@ -44,6 +43,11 @@ export default class NetworkStatus extends Component {
 
   renderTimestamp() {
     const { timestamp } = this.props
+
+    if (!timestamp) {
+      return '-'
+    }
+
     const { diffTimestamp } = this.state
     const diff = moment
       .unix(diffTimestamp)
@@ -58,9 +62,9 @@ export default class NetworkStatus extends Component {
     const { peers, blockNumber } = this.props
 
     return (
-      <StyledWrapper>
+      <StyledWrapper {...this.props}>
         <StyledRow>
-          <StyledIcon icon={faUsers} /> {peers} peers
+          <StyledIcon icon={faUsers} /> {peers || '-'} peers
         </StyledRow>
         <StyledRow>
           <StyledIcon icon={faLayerGroup} /> {blockNumber}
@@ -77,7 +81,9 @@ const StyledWrapper = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  color: #766a6a;
+  color: rgba(130, 122, 122, 0.7);
+  font-size: 0.75em;
+  padding: 0px 32px;
 `
 
 const StyledRow = styled.div`

--- a/src/components/Wallet/Notification.jsx
+++ b/src/components/Wallet/Notification.jsx
@@ -1,0 +1,20 @@
+import React, { Component } from 'react'
+// import PropTypes from 'prop-types'
+import styled from 'styled-components'
+
+export default class Notification extends Component {
+  static displayName = 'Notification'
+
+  static propTypes = {}
+
+  static defaultProps = {}
+
+  render() {
+    return <StyledWrapper>notification</StyledWrapper>
+  }
+}
+
+const StyledWrapper = styled.div`
+  padding: 12px 18px;
+  background-color: yellow;
+`

--- a/src/components/Wallet/Notification.jsx
+++ b/src/components/Wallet/Notification.jsx
@@ -1,20 +1,65 @@
 import React, { Component } from 'react'
-// import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import PropTypes from 'prop-types'
+import styled, { keyframes } from 'styled-components'
 
 export default class Notification extends Component {
   static displayName = 'Notification'
 
-  static propTypes = {}
+  static propTypes = {
+    /** Text displayed within the notification */
+    message: PropTypes.string.isRequired,
+    /** Callback function for clearing notification data (e.g. from a Redux store) */
+    dismiss: PropTypes.func,
+    /** Number of milliseconds to display notification */
+    delayMs: PropTypes.number
+  }
 
-  static defaultProps = {}
+  static defaultProps = {
+    delayMs: 8000
+  }
+
+  componentDidMount() {
+    const { dismiss, delayMs } = this.props
+
+    if (dismiss) {
+      setTimeout(dismiss, delayMs)
+    }
+  }
 
   render() {
-    return <StyledWrapper>notification</StyledWrapper>
+    const { message } = this.props
+
+    return <StyledWrapper {...this.props}>{message}</StyledWrapper>
   }
 }
 
+const slideBy = keyframes`
+  0% {
+    opacity: 0;
+    transform: translateX(400px);
+  }
+  10% {
+    opacity: 1;
+    transform: 0px;
+    transform: translateX(0px);
+  }
+  80% {
+    opacity: 1;
+    transform: translateX(0px);
+  }
+  100% {
+    opacity: 0;
+    transform: translateX(400px);
+  }
+`
+
 const StyledWrapper = styled.div`
+  opacity: 0;
+  max-width: 300px;
+  color: rgb(17, 17, 17);
+  display: inline-block;
+  margin: 0 12px 12px;
   padding: 12px 18px;
-  background-color: yellow;
+  background-color: rgb(254, 204, 9);
+  animation: ${slideBy} ${props => props.delayMs}ms;
 `

--- a/src/components/Widgets/Form/AddressInput.jsx
+++ b/src/components/Widgets/Form/AddressInput.jsx
@@ -72,7 +72,6 @@ export default class AddressInput extends Component {
 
 const StyledWrapper = styled.div`
   position: relative;
-  display: inline-block;
 `
 
 const StyledInput = styled(Input)`

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -26,6 +26,7 @@ import AccountItem from './Wallet/AccountItem'
 import TokenListForItem from './Wallet/TokenListForItem'
 import NavbarItem from './Wallet/NavbarItem'
 import NetworkStatus from './Wallet/NetworkStatus'
+import Notification from './Wallet/Notification'
 
 import * as utils from '../lib/util'
 
@@ -52,6 +53,7 @@ export {
   NetworkStatus,
   NodeInfo,
   NodeInfoBox,
+  Notification,
   Pulse,
   RpcTester,
   Spinner,

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -26,6 +26,10 @@ export const etherToGwei = valEther => {
   return new BNJS(valEther).times(new BNJS('1000000000'))
 }
 
+export const etherToWei = valEther => {
+  return new BNJS(valEther).times(new BNJS('1000000000000000000'))
+}
+
 export const toUsd = (etherAmount = '0', etherPriceUSD) => {
   return parseFloat(
     toBigNumber(etherAmount).times(toBigNumber(etherPriceUSD))

--- a/src/stories/5.wallet.stories.jsx
+++ b/src/stories/5.wallet.stories.jsx
@@ -6,7 +6,8 @@ import {
   AccountItem,
   AccountList,
   NavbarItem,
-  NetworkStatus
+  NetworkStatus,
+  Notification
 } from '../components'
 
 storiesOf('Wallet/NavbarItem', module)
@@ -127,3 +128,7 @@ storiesOf('Wallet/Account/Item', module)
       />
     )
   })
+
+storiesOf('Wallet/Notification', module).add('default', () => (
+  <Notification message="Example message" />
+))

--- a/src/stories/5.wallet.stories.jsx
+++ b/src/stories/5.wallet.stories.jsx
@@ -37,6 +37,7 @@ storiesOf('Wallet/NetworkStatus', module)
         .unix()}
     />
   ))
+  .add('empty state', () => <NetworkStatus />)
 
 storiesOf('Wallet/Account/List', module).add('default', () => {
   const accounts = [


### PR DESCRIPTION
#### What does it do?
- Introduces a `Notification` component (Closes #80)
- Cleans up some empty state for `NetworkStatus`
#### Any helpful background information?
- The animation is simple CSS (within styled-components)
- Notification data, in the case of the wallet, resides in the Redux store. For that reason, the `Notification` component makes sense to reside in the component lib, but `Notifications` (plural) lives in the wallet app, so that it can flush out the notification data after the 8 seconds (or other configurable) dismiss delay.
- This includes a warning/yellow color. Future iteration could introduce a `type` key which tweaks colors for error, success, etc.
#### Relevant screenshots?
multiple example usage in wallet. low frame rate, for no extra charge:
![](http://g.recordit.co/moALncLzPD.gif)