### PR TITLE
Fixes missing padding on remote node info box

### DIFF
--- a/src/components/Network/NodeInfo/NodeInfoBox.jsx
+++ b/src/components/Network/NodeInfo/NodeInfoBox.jsx
@@ -178,7 +178,7 @@ export default class NodeInfoBox extends Component {
     if (remote.blockNumber < 1000) {
       // Still loading initial remote results
       return (
-        <div id="remote-stats" className="node-info__section">
+        <StyledSection>
           <StyledTitle network="remote">
             <strong>Remote</strong> Node
           </StyledTitle>
@@ -188,7 +188,7 @@ export default class NodeInfoBox extends Component {
               {i18n.t('mist.nodeInfo.connecting')}
             </div>
           </div>
-        </div>
+        </StyledSection>
       )
     }
     return (


### PR DESCRIPTION
#### What does it do?
Fix missing padding on the remote info section of the NodeInfoBox component

#### Any helpful background information?

#### New dependencies? What are they used for?

#### Relevant screenshots?
<img width="238" alt="screen shot 2019-02-03 at 3 06 40 pm" src="https://user-images.githubusercontent.com/5225766/52183465-5931fe80-27c5-11e9-92c6-2468d920ffc2.png">

