### PR TITLE
fix: btn and spinner configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint:watch": "esw -w src --ext .jsx --ext .js",
     "lint": "eslint --fix src --ext .jsx --ext .js",
     "lint:style": "stylelint 'src/components/**/*.{js,jsx}'",
-    "pretty": "prettier --no-semi --single-quote --write 'src/**/*.js'"
+    "pretty": "prettier --no-semi --single-quote --write"
   },
   "peerDependencies": {
     "react": ">=16.6.3",
@@ -95,12 +95,16 @@
     }
   },
   "lint-staged": {
-    "*.{js,jsx,json,css,md}": "prettier --no-semi --single-quote --write",
-    "src/**/*.{js,jsx}": [
-      "yarn lint",
-      "yarn lint:style"
+    "*.{json,css,md}": [
+      "yarn pretty",
+      "git add"
     ],
-    "*": "git add"
+    "src/**/*.{js,jsx}": [
+      "yarn pretty",
+      "yarn lint",
+      "yarn lint:style",
+      "git add"
+    ]
   },
   "directories": {
     "doc": "docs"

--- a/src/components/Wallet/NavbarBalance.jsx
+++ b/src/components/Wallet/NavbarBalance.jsx
@@ -8,8 +8,7 @@ export default class NavbarBalance extends Component {
   static propTypes = {
     balance: PropTypes.string,
     currency: PropTypes.string,
-    network: PropTypes.string,
-    testButton: PropTypes.bool
+    network: PropTypes.string
   }
 
   static defaultProps = {
@@ -36,10 +35,6 @@ export default class NavbarBalance extends Component {
     }
   }
 
-  componentWillUnmount() {
-    this.mounted = false
-  }
-
   componentDidUpdate() {
     let { balance: bal1 } = this.state
     let { balance: bal2 } = this.props
@@ -48,6 +43,10 @@ export default class NavbarBalance extends Component {
     if (bal1 !== bal2) {
       this.changeBalance(bal1, bal2)
     }
+  }
+
+  componentWillUnmount() {
+    this.mounted = false
   }
 
   changeBalance = (bal1, bal2) => {
@@ -69,7 +68,7 @@ export default class NavbarBalance extends Component {
   }
 
   render() {
-    const { currency, network, testButton } = this.props
+    const { currency, network } = this.props
     const { balance } = this.state
 
     let currencySelect

--- a/src/components/Widgets/AnimatedIcons/Spinner.jsx
+++ b/src/components/Widgets/AnimatedIcons/Spinner.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
-import 'loaders.css'
+import styled, { keyframes } from 'styled-components'
 
 // for more examples see https://connoratherton.com/loaders
 // https://github.com/ConnorAtherton/loaders.css
@@ -9,8 +8,9 @@ export default class Spinner extends Component {
   static displayName = 'Spinner'
 
   static propTypes = {
+    color: PropTypes.string,
     scale: PropTypes.string,
-    color: PropTypes.string
+    style: PropTypes.object
   }
 
   static defaultProps = {
@@ -19,32 +19,88 @@ export default class Spinner extends Component {
   }
 
   render() {
-    const { color, scale } = this.props
+    const { color, scale, style } = this.props
 
     const divCount = 8
-    const style = { backgroundColor: color }
 
     return (
-      <StyledWrapper style={{ transform: `scale(${scale}, ${scale})` }}>
-        <div className="ball-spin-fade-loader">
-          {[...Array(divCount)].map((_, idx) => (
-            <div key={idx} style={style} />
-          ))}
-        </div>
+      <StyledWrapper
+        scale={scale}
+        style={{ transform: `scale(${scale}, ${scale})`, ...style }}
+      >
+        {[...Array(divCount)].map((_, idx) => (
+          <div key={idx} style={{ backgroundColor: color }} />
+        ))}
       </StyledWrapper>
     )
   }
 }
 
+const BallSpin = keyframes`
+  50% {
+    opacity: 0.3;
+    transform: scale(0.4);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+`
+
 const StyledWrapper = styled.div`
+  position: relative;
+  display: block;
+  width: 68px;
+  height: 68px;
   box-sizing: border-box;
-  display: flex;
-  flex: 0 1 auto;
-  flex-direction: column;
-  flex-grow: 1;
-  flex-shrink: 0;
-  flex-basis: 25%;
-  max-width: 25%;
-  align-items: center;
-  justify-content: center;
+
+  & > div {
+    background-color: #fff;
+    width: 15px;
+    height: 15px;
+    border-radius: 100%;
+    margin: 2px;
+    animation-fill-mode: both;
+    position: absolute;
+  }
+  & > div:nth-child(1) {
+    top: 50px;
+    left: 25px;
+    animation: ${BallSpin} 1s -0.96s infinite linear;
+  }
+  & > div:nth-child(2) {
+    top: 42.04545px;
+    left: 42.04545px;
+    animation: ${BallSpin} 1s -0.84s infinite linear;
+  }
+  & > div:nth-child(3) {
+    top: 25px;
+    left: 50px;
+    animation: ${BallSpin} 1s -0.72s infinite linear;
+  }
+  & > div:nth-child(4) {
+    top: 8.04545px;
+    left: 42.04545px;
+    animation: ${BallSpin} 1s -0.6s infinite linear;
+  }
+  & > div:nth-child(5) {
+    top: 0px;
+    left: 25px;
+    animation: ${BallSpin} 1s -0.48s infinite linear;
+  }
+  & > div:nth-child(6) {
+    top: 8.04545px;
+    left: 8.04545px;
+    animation: ${BallSpin} 1s -0.36s infinite linear;
+  }
+  & > div:nth-child(7) {
+    top: 25px;
+    left: 0;
+    animation: ${BallSpin} 1s -0.24s infinite linear;
+  }
+  & > div:nth-child(8) {
+    top: 42.04545px;
+    left: 8.04545px;
+    animation: ${BallSpin} 1s -0.12s infinite linear;
+  }
 `

--- a/src/components/Widgets/Button.jsx
+++ b/src/components/Widgets/Button.jsx
@@ -35,7 +35,14 @@ export default class Button extends Component {
     const { children, flat, loading, secondary, className } = this.props
 
     const spinner = (
-      <Spinner color={!secondary && !flat ? 'white' : '#00aafa'} scale="0.5" />
+      <React.Fragment>
+        <Spinner
+          color={!secondary && !flat ? 'white' : '#00aafa'}
+          scale="0.4"
+          style={{ position: 'absolute', right: '0' }}
+        />
+        {children}
+      </React.Fragment>
     )
 
     return (
@@ -47,6 +54,7 @@ export default class Button extends Component {
 }
 
 const StyledButton = styled.button`
+  position: relative;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -56,13 +64,12 @@ const StyledButton = styled.button`
   color: white;
   cursor: pointer;
   font-size: 14px;
-  height: 46px;
+  height: 46px !important;
   line-height: 1;
-  min-width: 120px;
+  min-width: 200px;
   overflow: hidden;
-  padding: 12px 24px;
   text-decoration: none;
-  text-transform: capitalize;
+  text-transform: uppercase;
   white-space: nowrap;
 
   ${props =>

--- a/src/stories/1.index.stories.jsx
+++ b/src/stories/1.index.stories.jsx
@@ -116,9 +116,9 @@ storiesOf('Widgets/Identicon', module)
     />
   ))
 
-storiesOf('Widgets/Animations/Spinner', module).add('default', () => (
-  <Spinner />
-))
+storiesOf('Widgets/Animations/Spinner', module)
+  .add('default', () => <Spinner />)
+  .add('half-size', () => <Spinner scale="0.5" />)
 
 storiesOf('Widgets/WalletButton', module).add('default', () => (
   <WalletButton onClick={() => {}}>Add Wallet Contract</WalletButton>


### PR DESCRIPTION
#### What does it do?
Lots of small cleanup.
- Fixes the lint-staged precommit script. I thought the tasks were synchronous, but they sure aren't.
- Fixes a couple outstanding lints.
- Spinner
  - Brings css into styled-components
  - Makes predictable inline-block sizes (vs. unwieldy absolute positioning)
- Button
  - Shrunk the size; looked fine in storybook, but when imported in mist-ui it blew up and looked awful.
  - Uppercases text
  - Loading state preserves btn text in addition to showing spinner. Spinner gets floated to the right. Don't think its a finished product yet, but it's slightly better. (Requested by @PhilippLgh.)
#### Any helpful background information?
- If not aware, @sarovin made a nice PR that introduced `stylelint`. That is new to the precommit pipeline.
- Tested mist-ui via npm link. See screenshot below for more sane padding and loading state.
#### Relevant screenshots?
Components in mist-ui: (btn manually set to 'loading')
<img width="486" alt="screen shot 2019-02-07 at 5 15 50 pm" src="https://user-images.githubusercontent.com/3621728/52451595-dd092500-2afc-11e9-9c0c-3dfacf76d1f0.png">
