### PR TITLE
fix: remove theme from lib

### DIFF
--- a/src/components/Widgets/AnimatedIcons/Spinner.jsx
+++ b/src/components/Widgets/AnimatedIcons/Spinner.jsx
@@ -1,18 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import CircularProgress from '@material-ui/core/CircularProgress'
-import { createMuiTheme, MuiThemeProvider } from '@material-ui/core/styles'
-
-const theme = createMuiTheme({
-  palette: {
-    primary: {
-      main: '#00A4FF'
-    },
-    secondary: {
-      main: '#ffffff'
-    }
-  }
-})
 
 export default class Spinner extends Component {
   static displayName = 'Spinner'
@@ -28,10 +16,6 @@ export default class Spinner extends Component {
   }
 
   render() {
-    return (
-      <MuiThemeProvider theme={theme}>
-        <CircularProgress {...this.props} />
-      </MuiThemeProvider>
-    )
+    return <CircularProgress {...this.props} />
   }
 }

--- a/src/components/Widgets/Button.jsx
+++ b/src/components/Widgets/Button.jsx
@@ -1,19 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import MuiButton from '@material-ui/core/Button'
-import { createMuiTheme, MuiThemeProvider } from '@material-ui/core/styles'
-
-const theme = createMuiTheme({
-  palette: {
-    primary: {
-      main: '#00A4FF',
-      contrastText: '#ffffff'
-    },
-    secondary: {
-      main: '#ffffff'
-    }
-  }
-})
 
 export default class Button extends Component {
   static displayName = 'Button'
@@ -38,15 +25,13 @@ export default class Button extends Component {
     const { children, secondary } = this.props
 
     return (
-      <MuiThemeProvider theme={theme}>
-        <MuiButton
-          {...this.props}
-          color={secondary ? 'secondary' : 'primary'}
-          variant="contained"
-        >
-          {children}
-        </MuiButton>
-      </MuiThemeProvider>
+      <MuiButton
+        {...this.props}
+        color={secondary ? 'secondary' : 'primary'}
+        variant="contained"
+      >
+        {children}
+      </MuiButton>
     )
   }
 }

--- a/src/components/Widgets/Form/Progress.jsx
+++ b/src/components/Widgets/Form/Progress.jsx
@@ -1,15 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import LinearProgress from '@material-ui/core/LinearProgress'
-import { createMuiTheme, MuiThemeProvider } from '@material-ui/core/styles'
-
-const theme = createMuiTheme({
-  palette: {
-    primary: {
-      main: '#00A4FF'
-    }
-  }
-})
 
 export default class Progress extends Component {
   static displayName = 'Progress'
@@ -30,10 +21,6 @@ export default class Progress extends Component {
   render() {
     const { variant } = this.props
 
-    return (
-      <MuiThemeProvider theme={theme}>
-        <LinearProgress {...this.props} variant={variant} />
-      </MuiThemeProvider>
-    )
+    return <LinearProgress {...this.props} variant={variant} />
   }
 }

--- a/src/components/Widgets/Form/Select.jsx
+++ b/src/components/Widgets/Form/Select.jsx
@@ -6,16 +6,6 @@ import MuiSelect from '@material-ui/core/Select'
 import OutlinedInput from '@material-ui/core/OutlinedInput'
 import InputLabel from '@material-ui/core/InputLabel'
 import MenuItem from '@material-ui/core/MenuItem'
-import { createMuiTheme, MuiThemeProvider } from '@material-ui/core/styles'
-
-const theme = createMuiTheme({
-  palette: {
-    primary: {
-      main: '#00A4FF',
-      contrastText: '#ffffff'
-    }
-  }
-})
 
 export default class Select extends Component {
   static displayName = 'Select'
@@ -68,27 +58,23 @@ export default class Select extends Component {
     ))
 
     return (
-      <MuiThemeProvider theme={theme}>
-        <FormControl variant="outlined" style={{ width: '100%' }}>
-          <InputLabel
-            ref={ref => {
-              this.InputLabelRef = ref
-            }}
-            htmlFor={id}
-          >
-            {name}
-          </InputLabel>
-          <MuiSelect
-            value={value}
-            onChange={this.handleChange}
-            input={
-              <OutlinedInput labelWidth={labelWidth} name={name} id={id} />
-            }
-          >
-            {opts}
-          </MuiSelect>
-        </FormControl>
-      </MuiThemeProvider>
+      <FormControl variant="outlined" style={{ width: '100%' }}>
+        <InputLabel
+          ref={ref => {
+            this.InputLabelRef = ref
+          }}
+          htmlFor={id}
+        >
+          {name}
+        </InputLabel>
+        <MuiSelect
+          value={value}
+          onChange={this.handleChange}
+          input={<OutlinedInput labelWidth={labelWidth} name={name} id={id} />}
+        >
+          {opts}
+        </MuiSelect>
+      </FormControl>
     )
   }
 }

--- a/src/stories/1.index.stories.jsx
+++ b/src/stories/1.index.stories.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { linkTo } from '@storybook/addon-links'
+import { createMuiTheme, MuiThemeProvider } from '@material-ui/core/styles'
 import Welcome from './Welcome'
 
 import {
@@ -22,6 +23,18 @@ import {
 } from '../components'
 import Checkmark from '../components/Widgets/AnimatedIcons/Checkmark'
 import Cross from '../components/Widgets/AnimatedIcons/Cross'
+
+const theme = createMuiTheme({
+  palette: {
+    primary: {
+      main: '#00A4FF',
+      contrastText: '#ffffff'
+    },
+    secondary: {
+      main: '#ffffff'
+    }
+  }
+})
 
 const dummyWallets = {
   '0x2685F863Ddb456601783A57A1C3E9F8f3ebc6c3B': {
@@ -144,7 +157,7 @@ storiesOf('Widgets/Identicon', module)
   ))
 
 storiesOf('Widgets/Progress', module).add('index', () => (
-  <div>
+  <MuiThemeProvider theme={theme}>
     <Progress value={40} />
     <br />
     <Progress variant="indeterminate" />
@@ -152,29 +165,31 @@ storiesOf('Widgets/Progress', module).add('index', () => (
     <Progress variant="buffer" value={60} valueBuffer={70} />
     <br />
     <Progress variant="query" />
-  </div>
+  </MuiThemeProvider>
 ))
 
 storiesOf('Widgets/Animations/Spinner', module).add('index', () => (
-  <div>
-    <Spinner />
-    <Spinner size={30} />
-    <Spinner size={20} />
+  <MuiThemeProvider theme={theme}>
+    <div>
+      <Spinner />
+      <Spinner size={30} />
+      <Spinner size={20} />
 
-    <br />
-    <br />
-    <div
-      style={{
-        backgroundColor: 'black',
-        padding: '20px',
-        display: 'inline-block'
-      }}
-    >
-      <Spinner color="secondary" />
-      <Spinner color="secondary" size={30} />
-      <Spinner color="secondary" size={20} />
+      <br />
+      <br />
+      <div
+        style={{
+          backgroundColor: 'black',
+          padding: '20px',
+          display: 'inline-block'
+        }}
+      >
+        <Spinner color="secondary" />
+        <Spinner color="secondary" size={30} />
+        <Spinner color="secondary" size={20} />
+      </div>
     </div>
-  </div>
+  </MuiThemeProvider>
 ))
 
 storiesOf('Widgets/WalletButton', module).add('default', () => (
@@ -194,20 +209,22 @@ storiesOf('Widgets/Animations/Icons', module)
 
 storiesOf('Widgets/Button', module).add('index', () => {
   return (
-    <div>
-      <Button>click me</Button>
-      <br />
-      <br />
-      <Button disabled>click me</Button>
-      <br />
-      <br />
-      <Button secondary>click me</Button>
-      <br />
-      <br />
-      <Button secondary disabled>
-        click me
-      </Button>
-    </div>
+    <MuiThemeProvider theme={theme}>
+      <div>
+        <Button>click me</Button>
+        <br />
+        <br />
+        <Button disabled>click me</Button>
+        <br />
+        <br />
+        <Button secondary>click me</Button>
+        <br />
+        <br />
+        <Button secondary disabled>
+          click me
+        </Button>
+      </div>
+    </MuiThemeProvider>
   )
 })
 
@@ -247,14 +264,17 @@ storiesOf('Widgets/Form/Select', module).add('index', () => {
     { value: 4, label: 'rinkeby' },
     { value: 42, label: 'kovan' }
   ]
+
   return (
-    <Select
-      name="network"
-      id="colors-select"
-      defaultValue={4}
-      onChange={e => alert(`Value: ${e}`)}
-      options={options}
-    />
+    <MuiThemeProvider theme={theme}>
+      <Select
+        name="network"
+        id="colors-select"
+        defaultValue={4}
+        onChange={e => alert(`Value: ${e}`)}
+        options={options}
+      />
+    </MuiThemeProvider>
   )
 })
 


### PR DESCRIPTION
#### What does it do?
- Remove material-ui theme from individual components to allow for app-wide themes in mist-ui.
#### Any helpful background information?
- Storybook still has desired theme; it's implemented in the stories now.