### PR TITLE
fix: btn API

### DIFF
--- a/src/components/Widgets/Button.jsx
+++ b/src/components/Widgets/Button.jsx
@@ -7,31 +7,33 @@ export default class Button extends Component {
 
   static propTypes = {
     children: PropTypes.node,
+    color: PropTypes.oneOf(['primary', 'secondary']),
     disabled: PropTypes.bool,
     onClick: PropTypes.func,
     secondary: PropTypes.bool,
     type: PropTypes.oneOf(['button', 'reset', 'submit']),
-    /** If `true`, extra margin is added. See `SubmitTxForm` component for example usage. */
-    className: PropTypes.string
+    className: PropTypes.string,
+    variant: PropTypes.oneOf([
+      'text',
+      'outlined',
+      'contained',
+      'fab',
+      'extendedFab',
+      'flat',
+      'raised'
+    ])
   }
 
   static defaultProps = {
+    color: 'primary',
     disabled: false,
-    secondary: false,
-    type: 'button'
+    type: 'button',
+    variant: 'contained'
   }
 
   render() {
-    const { children, secondary } = this.props
+    const { children } = this.props
 
-    return (
-      <MuiButton
-        {...this.props}
-        color={secondary ? 'secondary' : 'primary'}
-        variant="contained"
-      >
-        {children}
-      </MuiButton>
-    )
+    return <MuiButton {...this.props}>{children}</MuiButton>
   }
 }

--- a/src/stories/1.index.stories.jsx
+++ b/src/stories/1.index.stories.jsx
@@ -25,6 +25,9 @@ import Checkmark from '../components/Widgets/AnimatedIcons/Checkmark'
 import Cross from '../components/Widgets/AnimatedIcons/Cross'
 
 const theme = createMuiTheme({
+  typography: {
+    useNextVariants: true
+  },
   palette: {
     primary: {
       main: '#00A4FF',
@@ -217,10 +220,10 @@ storiesOf('Widgets/Button', module).add('index', () => {
         <Button disabled>click me</Button>
         <br />
         <br />
-        <Button secondary>click me</Button>
+        <Button color="secondary">click me</Button>
         <br />
         <br />
-        <Button secondary disabled>
+        <Button color="secondary" disabled>
           click me
         </Button>
       </div>


### PR DESCRIPTION
#### What does it do?
Cleans up the Button API.
#### Any helpful background information?
- Resolves the warning: `Received 'false' for a non-boolean attribute 'secondary'`
- Gets closer to the material-ui API, so there should be fewer surprises for devs already comfortable with material-ui.
- API changes slightly: instead of 
`<Button secondary>Click Me</Button>`
replace with:
`<Button color="secondary">Click Me</Button>`
