### PR TITLE
fix: url-loader for imgs

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "stylelint-config-styled-components": "^0.1.1",
     "stylelint-processor-styled-components": "^1.5.1",
     "terser-webpack-plugin": "^1.2.3",
+    "url-loader": "^1.1.2",
     "webpack": "^4.26.0",
     "webpack-cli": "^3.1.2"
   },

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -29,8 +29,8 @@ module.exports = {
           // https://github.com/webpack-contrib/terser-webpack-plugin#terseroptions
           mangle: false
         }
-      }),
-    ],
+      })
+    ]
   },
   module: {
     rules: [
@@ -45,8 +45,8 @@ module.exports = {
         }
       },
       {
-        test: /\.(png|jpg|gif|svg)$/i,
-        loaders: ['file-loader']
+        test: /\.(png|jpg|gif)$/,
+        loaders: ['url-loader?limit=8192']
       },
       {
         test: /\.scss$/,


### PR DESCRIPTION
#### What does it do?
Swaps `file-loader` for `url-loader` to bundle image assets via webpack.
#### Any helpful background information?
- `url-loader` inlines base64 URLs
- i don't think it supports svgs, but we don't package any of those for now.
#### New dependencies? What are they used for?
`url-loader` (already installed as a dep of storybook, though)
#### Relevant screenshots?
test app - before:
![screen shot 2019-03-05 at 1 40 29 pm](https://user-images.githubusercontent.com/3621728/53837027-c9f84200-3f4e-11e9-944f-317e4b3e0ea3.png)
after:
![screen shot 2019-03-05 at 1 42 06 pm](https://user-images.githubusercontent.com/3621728/53837026-c95fab80-3f4e-11e9-838e-4f15790f865b.png)