### PR TITLE
docs: updates Mist references, etc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,8 @@ First, thanks for your interest! We appreciate your time.
 This library is primarily maintained by the Mist team at the Ethereum Foundation. Mist was recently refactored into several projects; you can learn more about its constituent parts here:
 
 - ethereum-react-components (this repo) - a React component library
-- [mist-ui](https://github.com/ethereum/mist-ui) - uses the component library to assemble Mist's user interface
-- [mist-shell](https://github.com/ethereum/mist-shell) - the desktop app wrapper for mist-ui
+- [grid-ui](https://github.com/ethereum/grid-ui) - uses the component library to assemble Grid's user interface
+- [grid](https://github.com/ethereum/grid) - the desktop app wrapper for grid-ui
 - [electron-app-manager](https://github.com/PhilippLgh/electron-app-manager) - handles app updates
 
 #### How can I contribute?

--- a/README.md
+++ b/README.md
@@ -1,20 +1,12 @@
-[![CircleCI](https://circleci.com/gh/ethereum/ethereum-react-components.svg?style=shield)](https://circleci.com/gh/ethereum/ethereum-react-components)
-
-Live Storybook: https://ethereum.github.io/ethereum-react-components
-
-Test URL (`dev` branch): https://ethereum-react-components-dev.netlify.com/
-
 # Ethereum React Components
 
 A library of frequently used Ethereum components.
 
-All available components can be found in the the project [storybook](https://ethereum.github.io/ethereum-react-components).
+All available components can be found in the the project [storybook](https://ethereum.github.io/ethereum-react-components). The bleeding edge (`dev` branch) gets published [here](https://ethereum-react-components-dev.netlify.com/).
 
 WARNING: this lib is not production ready. All component APIs are in exploratory phases and strict semantic versioning is not yet enforced.
 
 ## Installation
-
-Our CI automatically bundles and publishes the latest production version to [npm](https://www.npmjs.com/package/ethereum-react-components) and [GitHub Releases](https://github.com/ethereum/ethereum-react-components/releases)
 
 ```
 yarn add ethereum-react-components
@@ -36,7 +28,7 @@ Note that this storybook uses the [Source Sans Pro](https://fonts.google.com/spe
 
 ## Contributing
 
-There are many ways to get involved with this project. Get started [here](/docs/CONTRIBUTING.md).
+There are many ways to get involved with this project. Get started [here](/CONTRIBUTING.md).
 
 ## Development
 
@@ -57,11 +49,11 @@ yarn storybook
 
 ### Local Testing
 
-While in development, [npm link](https://docs.npmjs.com/cli/link.html) allows for testing this library on another local project without publishing to npm.
+While in development, [yarn link](https://yarnpkg.com/lang/en/docs/cli/link/) allows for testing this library on another local project without publishing to npm.
 
 ```
 cd ethereum-react-components
 yarn link
 cd my/project/with/ethereum/components
-yarn link "ethereum-react-components"
+yarn link ethereum-react-components
 ```


### PR DESCRIPTION
#### What does it do?
- Removes Mist references.
- Moves CONTRIBUTING doc outside of messy storybook docs dir.
- Small cleanup
#### Any helpful background information?
Testing the netlify preview builder.